### PR TITLE
Fix selection list tile to handle long text

### DIFF
--- a/lib/src/views/widget/selection_list_tile.dart
+++ b/lib/src/views/widget/selection_list_tile.dart
@@ -20,7 +20,7 @@ class SelectionListTile extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 14.0),
           child: ListTile(
-            leading: Text(
+            title: Text(
               text,
               style: Theme.of(context).textTheme.headline5?.copyWith(
                     color: isSelected


### PR DESCRIPTION
- When using `TextChoice` with a very long text, the plugin currently throws an error and does not render the view

  ```dart
  TextChoice(
    text: 'This is an extremely long option which will overflow',
    value: 'value',
  ),
  ```

- This PR fixes this behaviour by assigning the text to `title` instead of `leading` in the `ListTile`