### PR TITLE
Fix close survey with survey controller

### DIFF
--- a/lib/src/controller/survey_controller.dart
+++ b/lib/src/controller/survey_controller.dart
@@ -41,7 +41,6 @@ class SurveyController {
   ///      resultFunction.call(),
   ///    ),
   /// );
-  /// Navigator.pop(context);
   /// ```
   final Function(
     BuildContext context,
@@ -97,6 +96,5 @@ class SurveyController {
         resultFunction.call(),
       ),
     );
-    Navigator.pop(context);
   }
 }

--- a/lib/src/survey_kit.dart
+++ b/lib/src/survey_kit.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 import 'package:survey_kit/src/controller/survey_controller.dart';
@@ -73,19 +72,18 @@ class _SurveyKitState extends State<SurveyKit> {
           create: (BuildContext context) => SurveyPresenter(
             taskNavigator: _taskNavigator,
           ),
-          child: BlocBuilder<SurveyPresenter, SurveyState>(
+          child: BlocConsumer<SurveyPresenter, SurveyState>(
+            listenWhen: (previous, current) => previous != current,
+            listener: (context, state) async {
+              if (state is SurveyResultState) {
+                widget.onResult.call(state.result);
+                Navigator.of(context).pop();
+              }
+            },
             builder: (BuildContext context, SurveyState state) {
               if (state is PresentingSurveyState) {
                 return state.currentStep.createView(
                   questionResult: state.result,
-                );
-              }
-              if (state is SurveyResultState) {
-                widget.onResult.call(state.result);
-                SchedulerBinding.instance?.addPostFrameCallback(
-                  (_) {
-                    Navigator.pop(context);
-                  },
                 );
               }
               return Center(


### PR DESCRIPTION
**Problem**
1. In `SurveyController.closeSurvey`, it adds a `CloseSurvey` event and calls `Navigator.pop`
2. The `CloseSurvey` updates the `SurveyState` state to `SurveyResultState`
3. The `SurveyResultState` gets handled by `SurveyKit` where `Navigator.pop` is called again
4. This results in popping the navigation stack twice

**Solution**
- Remove the `Navigator.pop` call in `SurveyController.closeSurvey` so that it's only being called once in `SurveyKit`
- Refactor `SurveyKit` to use `BlocConsumer` and move the handling of `SurveyResultState` to the `listener` callback