### PR TITLE
add option to add a custom asset to CompletionStep #35,#52

### DIFF
--- a/lib/src/steps/predefined_steps/completion_step.dart
+++ b/lib/src/steps/predefined_steps/completion_step.dart
@@ -11,6 +11,7 @@ part 'completion_step.g.dart';
 class CompletionStep extends Step {
   final String title;
   final String text;
+  final String assetPath;
 
   CompletionStep({
     bool isOptional = false,
@@ -19,6 +20,7 @@ class CompletionStep extends Step {
     bool showAppBar = true,
     required this.title,
     required this.text,
+    this.assetPath = ""
   }) : super(
           stepIdentifier: stepIdentifier,
           isOptional: isOptional,
@@ -28,7 +30,7 @@ class CompletionStep extends Step {
 
   @override
   Widget createView({required QuestionResult? questionResult}) {
-    return CompletionView(completionStep: this);
+    return CompletionView(completionStep: this, assetPath: assetPath);
   }
 
   factory CompletionStep.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/steps/predefined_steps/completion_step.g.dart
+++ b/lib/src/steps/predefined_steps/completion_step.g.dart
@@ -14,6 +14,7 @@ CompletionStep _$CompletionStepFromJson(Map<String, dynamic> json) {
     buttonText: json['buttonText'] as String? ?? 'Next',
     title: json['title'] as String,
     text: json['text'] as String,
+    assetPath: json['assetPath'] as String,
   );
 }
 
@@ -24,4 +25,5 @@ Map<String, dynamic> _$CompletionStepToJson(CompletionStep instance) =>
       'buttonText': instance.buttonText,
       'title': instance.title,
       'text': instance.text,
+      'assetPath': instance.assetPath,
     };

--- a/lib/src/views/completion_view.dart
+++ b/lib/src/views/completion_view.dart
@@ -7,8 +7,9 @@ import 'package:survey_kit/src/views/widget/step_view.dart';
 class CompletionView extends StatelessWidget {
   final CompletionStep completionStep;
   final DateTime _startDate = DateTime.now();
+  final String assetPath;
 
-  CompletionView({required this.completionStep});
+  CompletionView({required this.completionStep, this.assetPath = ""});
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +36,12 @@ class CompletionView extends StatelessWidget {
               child: Container(
                 width: 150.0,
                 height: 150.0,
-                child: Lottie.asset(
+                child: assetPath.isNotEmpty
+                ? Lottie.asset(
+                  assetPath,
+                  repeat: false,
+                )
+                : Lottie.asset(
                   'assets/fancy_checkmark.json',
                   package: 'survey_kit',
                   repeat: false,


### PR DESCRIPTION
Added option to use a custom Lottie asset in CompletionStep. The default asset is used if no custom path is defined. Related to issues #35 and #52.